### PR TITLE
Add Project convention to add support for finding variants of projects and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,4 +340,43 @@ buildAspects.subprojects {
 }
 ```
 
+### `Project` extensions API
 
+The plugin adds extra convention methods to the `Project` object of every project in the build.
+These methods help to navigate variant projects more easily.
+
+#### `findProject(String, Variant)`
+
+Next to the builtin Gradle [`Project#findProject(String)`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#findProject-java.lang.String-) method,
+an extra method is added to find a build variant sub-project.
+
+The first argument is the path to the base project that is registered with the `buildAspects` settings.
+The second argument is a `Variant` instance that specifies which sub-project to select.
+At the moment, it is not possible to create `Variant`s yourself, but you can use the exposed `buildVariant` object to find a project that matches the build variant of your project.
+
+```groovy
+// build.gradle
+buildAspects.subprojects {
+    def moduleA = findProject(":moduleA", buildVariant)
+}
+```
+
+### `project(String, Variant)`
+
+This method is an extension of the builtin [`Project#project(String)`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#project-java.lang.String-) method.
+It works in the same way as `#findProject(String, Variant)`, but throws an exception when a project is not found instead of returning null.
+
+### `variantTask(String, Variant, String)`
+
+The `variantTask` method makes it easy to create a reference to a task in a variant project.
+
+The first 2 arguments are used to resolve the project using `#project(String, Variant)`.
+The 3rd arguments is the name of the task.
+
+```groovy
+// build.gradle
+buildAspects.subprojects {
+    // Add a dependency to the check task on the project that matches this buildVariant in :moduleA
+    test.dependsOn(variantTask(":moduleA", buildVariant, "check"))
+}
+```

--- a/src/integrationTest/resources/be/vbgn/gradle/buildaspects/integration/subprojects/moduleA/build.gradle
+++ b/src/integrationTest/resources/be/vbgn/gradle/buildaspects/integration/subprojects/moduleA/build.gradle
@@ -17,3 +17,14 @@ afterEvaluate {
     assert system1ProjectCalled
     assert !system3ProjectCalled
 }
+
+buildAspects.subprojects {
+    def siblingProject = findProject(":systemB:moduleB", buildVariant);
+    assert siblingProject != null
+    assert siblingProject.buildVariant.properties == buildVariant.properties
+}
+
+buildAspects.withVariant("systemVersion", "1.0") {
+    assert findProject(':systemB:moduleB', buildVariant).path == ":systemB:moduleB:moduleB-systemVersion-1.0"
+    assert variantTask(':systemB:moduleB', buildVariant, 'clean') == ":systemB:moduleB:moduleB-systemVersion-1.0:clean"
+}

--- a/src/main/java/be/vbgn/gradle/buildaspects/BuildAspectsPlugin.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/BuildAspectsPlugin.java
@@ -6,8 +6,10 @@ package be.vbgn.gradle.buildaspects;
 import be.vbgn.gradle.buildaspects.project.dsl.BuildAspectsLeaf;
 import be.vbgn.gradle.buildaspects.project.dsl.BuildAspectsParent;
 import be.vbgn.gradle.buildaspects.project.dsl.BuildVariant;
+import be.vbgn.gradle.buildaspects.project.dsl.ProjectExtension;
 import be.vbgn.gradle.buildaspects.project.project.VariantProject;
 import be.vbgn.gradle.buildaspects.project.project.VariantProjectFactory;
+import be.vbgn.gradle.buildaspects.project.project.VariantProjectFactoryImpl;
 import be.vbgn.gradle.buildaspects.settings.dsl.BuildAspects;
 import be.vbgn.gradle.buildaspects.settings.dsl.BuildAspectsRoot;
 import java.util.Set;
@@ -19,13 +21,17 @@ public class BuildAspectsPlugin implements Plugin<Object> {
 
     private static final String BUILD_ASPECTS_EXTENSION = "buildAspects";
     private static final String BUILD_VARIANT_EXTENSION = "buildVariant";
+    private static final String BUILD_ASPECTS_CONVENTION = "buildAspects-convention";
 
     public void apply(Settings settings) {
         BuildAspects buildAspects = settings.getExtensions()
                 .create(BUILD_ASPECTS_EXTENSION, BuildAspectsRoot.class, settings);
-        VariantProjectFactory variantProjectFactory = new VariantProjectFactory(
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryImpl(
                 buildAspects.getVariantProjects());
         settings.getGradle().allprojects(project -> {
+            // Add overload to findProject() and project() methods
+            project.getConvention().getPlugins()
+                    .put(BUILD_ASPECTS_CONVENTION, new ProjectExtension(project, variantProjectFactory));
             // Applies if project is a leaf project
             variantProjectFactory.createVariantProject(project)
                     .ifPresent(vp -> {

--- a/src/main/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtension.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtension.java
@@ -1,0 +1,55 @@
+package be.vbgn.gradle.buildaspects.project.dsl;
+
+import be.vbgn.gradle.buildaspects.project.project.VariantProject;
+import be.vbgn.gradle.buildaspects.project.project.VariantProjectFactory;
+import be.vbgn.gradle.buildaspects.variant.Variant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.UnknownProjectException;
+
+public class ProjectExtension {
+    private final Project thisProject;
+    private final VariantProjectFactory variantProjectFactory;
+
+    @Inject
+    public ProjectExtension(Project thisProject, VariantProjectFactory variantProjectFactory) {
+        this.thisProject = thisProject;
+        this.variantProjectFactory = variantProjectFactory;
+    }
+
+    @Nullable
+    public Project findProject(String baseProject, Variant variant) {
+        Project parentProject = thisProject.findProject(baseProject);
+        if(parentProject == null) {
+            return null;
+        }
+
+        AtomicBoolean foundProject = new AtomicBoolean(false);
+
+        return variantProjectFactory.createVariantProjectsForParent(parentProject)
+                .stream()
+                .filter(variantProject -> variantProject.getVariant().getProperties().equals(variant.getProperties()))
+                .map(VariantProject::getProject)
+                .peek(project -> {
+                    if(foundProject.getAndSet(true)) {
+                        throw new IllegalStateException("Multiple projects found for parent "+parentProject+" and "+variant);
+                    }
+                })
+                .findAny()
+                .orElse(null);
+    }
+
+    public Project project(String baseProject, Variant variant) {
+        Project project = findProject(baseProject, variant);
+        if(project == null) {
+            throw new UnknownProjectException(String.format("Project with path '%s' and variant '%s' could not be found in %s.", baseProject, variant, this));
+        }
+        return project;
+    }
+
+    public String variantTask(String baseProject, Variant variant, String taskName) {
+        return project(baseProject, variant).getPath()+":"+taskName;
+    }
+}

--- a/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProject.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProject.java
@@ -1,48 +1,11 @@
 package be.vbgn.gradle.buildaspects.project.project;
 
 import be.vbgn.gradle.buildaspects.variant.Variant;
-import java.util.Objects;
 import org.gradle.api.Project;
 
-public class VariantProject {
+public interface VariantProject {
 
-    private final Variant variant;
-    private final Project project;
+    Project getProject();
 
-
-    VariantProject(Project project, Variant variant) {
-        this.variant = variant;
-        this.project = project;
-    }
-
-    public Project getProject() {
-        return project;
-    }
-
-    public Variant getVariant() {
-        return variant;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        VariantProject that = (VariantProject) o;
-        return getVariant().equals(that.getVariant()) &&
-                getProject().equals(that.getProject());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getVariant(), getProject());
-    }
-
-    @Override
-    public String toString() {
-        return "VariantProject{" + project + " (" + variant + ")}";
-    }
+    Variant getVariant();
 }

--- a/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactory.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactory.java
@@ -1,49 +1,12 @@
 package be.vbgn.gradle.buildaspects.project.project;
 
-import be.vbgn.gradle.buildaspects.settings.project.VariantProjectDescriptor;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Project;
 
-public class VariantProjectFactory {
+public interface VariantProjectFactory {
 
-    private final Set<? extends VariantProjectDescriptor> variantProjectDescriptors;
+    Optional<VariantProject> createVariantProject(Project project);
 
-    private final Map<Project, VariantProject> variantProjectCache;
-
-    public VariantProjectFactory(Set<? extends VariantProjectDescriptor> variantProjectDescriptors) {
-        this.variantProjectDescriptors = variantProjectDescriptors;
-        variantProjectCache = new HashMap<>(variantProjectDescriptors.size());
-    }
-
-    private VariantProject createVariantProject(Project project, VariantProjectDescriptor descriptor) {
-        assert project.getPath().equals(descriptor.getProjectDescriptor().getPath());
-        variantProjectCache.computeIfAbsent(project, p -> new VariantProject(p, descriptor.getVariant()));
-        return variantProjectCache.get(project);
-    }
-
-    public Optional<VariantProject> createVariantProject(Project project) {
-        for (VariantProjectDescriptor variantProjectDescriptor : variantProjectDescriptors) {
-            if (variantProjectDescriptor.getProjectDescriptor().getPath().equals(project.getPath())) {
-                return Optional.of(createVariantProject(project, variantProjectDescriptor));
-            }
-        }
-        return Optional.empty();
-    }
-
-    public Set<VariantProject> createVariantProjectsForParent(Project parentProject) {
-        Set<VariantProject> childVariantProjects = new HashSet<>(parentProject.getChildProjects().size());
-        for (VariantProjectDescriptor variantProjectDescriptor : variantProjectDescriptors) {
-            if (variantProjectDescriptor.getParentProjectDescriptor().getPath().equals(parentProject.getPath())) {
-                Project childProject = parentProject
-                        .project(variantProjectDescriptor.getProjectDescriptor().getPath());
-                childVariantProjects.add(createVariantProject(childProject, variantProjectDescriptor));
-            }
-        }
-        return Collections.unmodifiableSet(childVariantProjects);
-    }
+    Set<VariantProject> createVariantProjectsForParent(Project parentProject);
 }

--- a/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactoryImpl.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactoryImpl.java
@@ -1,0 +1,51 @@
+package be.vbgn.gradle.buildaspects.project.project;
+
+import be.vbgn.gradle.buildaspects.settings.project.VariantProjectDescriptor;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.gradle.api.Project;
+
+public class VariantProjectFactoryImpl implements VariantProjectFactory {
+
+    private final Set<? extends VariantProjectDescriptor> variantProjectDescriptors;
+
+    private final Map<Project, VariantProject> variantProjectCache;
+
+    public VariantProjectFactoryImpl(Set<? extends VariantProjectDescriptor> variantProjectDescriptors) {
+        this.variantProjectDescriptors = variantProjectDescriptors;
+        variantProjectCache = new HashMap<>(variantProjectDescriptors.size());
+    }
+
+    private VariantProject createVariantProject(Project project, VariantProjectDescriptor descriptor) {
+        assert project.getPath().equals(descriptor.getProjectDescriptor().getPath());
+        variantProjectCache.computeIfAbsent(project, p -> new VariantProjectImpl(p, descriptor.getVariant()));
+        return variantProjectCache.get(project);
+    }
+
+    @Override
+    public Optional<VariantProject> createVariantProject(Project project) {
+        for (VariantProjectDescriptor variantProjectDescriptor : variantProjectDescriptors) {
+            if (variantProjectDescriptor.getProjectDescriptor().getPath().equals(project.getPath())) {
+                return Optional.of(createVariantProject(project, variantProjectDescriptor));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<VariantProject> createVariantProjectsForParent(Project parentProject) {
+        Set<VariantProject> childVariantProjects = new HashSet<>(parentProject.getChildProjects().size());
+        for (VariantProjectDescriptor variantProjectDescriptor : variantProjectDescriptors) {
+            if (variantProjectDescriptor.getParentProjectDescriptor().getPath().equals(parentProject.getPath())) {
+                Project childProject = parentProject
+                        .project(variantProjectDescriptor.getProjectDescriptor().getPath());
+                childVariantProjects.add(createVariantProject(childProject, variantProjectDescriptor));
+            }
+        }
+        return Collections.unmodifiableSet(childVariantProjects);
+    }
+}

--- a/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectImpl.java
+++ b/src/main/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectImpl.java
@@ -1,0 +1,50 @@
+package be.vbgn.gradle.buildaspects.project.project;
+
+import be.vbgn.gradle.buildaspects.variant.Variant;
+import java.util.Objects;
+import org.gradle.api.Project;
+
+public class VariantProjectImpl implements VariantProject {
+
+    private final Variant variant;
+    private final Project project;
+
+
+    VariantProjectImpl(Project project, Variant variant) {
+        this.variant = variant;
+        this.project = project;
+    }
+
+    @Override
+    public Project getProject() {
+        return project;
+    }
+
+    @Override
+    public Variant getVariant() {
+        return variant;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VariantProject that = (VariantProject) o;
+        return getVariant().equals(that.getVariant()) &&
+                getProject().equals(that.getProject());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVariant(), getProject());
+    }
+
+    @Override
+    public String toString() {
+        return "VariantProject{" + project + " (" + variant + ")}";
+    }
+}

--- a/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/BuildAspectsParentTest.java
+++ b/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/BuildAspectsParentTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import be.vbgn.gradle.buildaspects.TestUtil;
 import be.vbgn.gradle.buildaspects.project.project.VariantProject;
+import be.vbgn.gradle.buildaspects.project.project.VariantProjectImpl;
 import be.vbgn.gradle.buildaspects.variant.Variant;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -16,7 +17,7 @@ import org.mockito.Mockito;
 public class BuildAspectsParentTest {
 
     private VariantProject createVariantProject(Project project, Variant variant) {
-        VariantProject variantProject = Mockito.mock(VariantProject.class, Mockito.RETURNS_SMART_NULLS);
+        VariantProject variantProject = Mockito.mock(VariantProjectImpl.class, Mockito.RETURNS_SMART_NULLS);
         Mockito.when(variantProject.getProject()).thenReturn(project);
         Mockito.when(variantProject.getVariant()).thenReturn(variant);
         return variantProject;

--- a/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtensionTest.java
+++ b/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtensionTest.java
@@ -91,6 +91,32 @@ public class ProjectExtensionTest {
         assertNull(moduleA3Project);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void findProjectIllegalState() {
+        Variant version1 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"));
+        Variant version2 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"));
+        Project rootProject = ProjectBuilder.builder().build();
+        Project moduleA = ProjectBuilder.builder().withName("moduleA").withParent(rootProject).build();
+        Project moduleA1 = ProjectBuilder.builder().withName("moduleA-1").withParent(moduleA).build();
+        Project moduleA2 = ProjectBuilder.builder().withName("moduleA-2").withParent(moduleA).build();
+        Project moduleB = ProjectBuilder.builder().withName("moduleB").withParent(rootProject).build();
+        Project moduleB1 = ProjectBuilder.builder().withName("moduleB-1").withParent(moduleB).build();
+        Project moduleB1bis = ProjectBuilder.builder().withName("moduleB-1bis").withParent(moduleB).build();
+        Project moduleB2 = ProjectBuilder.builder().withName("moduleB-2").withParent(moduleB).build();
+        Map<Project, Variant> projectVariantMap = new HashMap<>();
+        projectVariantMap.put(moduleA1, version1);
+        projectVariantMap.put(moduleA2, version2);
+        projectVariantMap.put(moduleB1, version1);
+        projectVariantMap.put(moduleB1bis, version1);
+        projectVariantMap.put(moduleB2, version2);
+
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryMock(projectVariantMap);
+        ProjectExtension projectExtension = new ProjectExtension(rootProject, variantProjectFactory);
+
+        projectExtension.findProject(":moduleB", version1);
+    }
+
+    @Test
     public void project() {
         Variant version1 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"));
         Variant version2 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"));

--- a/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtensionTest.java
+++ b/src/test/java/be/vbgn/gradle/buildaspects/project/dsl/ProjectExtensionTest.java
@@ -1,0 +1,150 @@
+package be.vbgn.gradle.buildaspects.project.dsl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import be.vbgn.gradle.buildaspects.TestUtil;
+import be.vbgn.gradle.buildaspects.project.project.VariantProject;
+import be.vbgn.gradle.buildaspects.project.project.VariantProjectFactory;
+import be.vbgn.gradle.buildaspects.variant.Variant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.Project;
+import org.gradle.api.UnknownProjectException;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Test;
+
+public class ProjectExtensionTest {
+
+    private static class VariantProjectFactoryMock implements VariantProjectFactory {
+
+        private Map<Project, ? extends Variant> projectVariants;
+
+        private VariantProjectFactoryMock(Map<Project, ? extends Variant> projectVariants) {
+            this.projectVariants = projectVariants;
+        }
+
+        @Override
+        public Optional<VariantProject> createVariantProject(Project project) {
+            return Optional.ofNullable(projectVariants.get(project))
+                    .map(variant -> new VariantProject() {
+                        @Override
+                        public Project getProject() {
+                            return project;
+                        }
+
+                        @Override
+                        public Variant getVariant() {
+                            return variant;
+                        }
+                    });
+        }
+
+        @Override
+        public Set<VariantProject> createVariantProjectsForParent(Project parentProject) {
+            return parentProject.getChildProjects()
+                    .values()
+                    .stream()
+                    .flatMap(project -> createVariantProject(project)
+                            .map(Stream::of)
+                            .orElseGet(Stream::empty))
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    @Test
+    public void findProject() {
+        Variant version1 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"));
+        Variant version2 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"));
+        Project rootProject = ProjectBuilder.builder().build();
+        Project moduleA = ProjectBuilder.builder().withName("moduleA").withParent(rootProject).build();
+        Project moduleA1 = ProjectBuilder.builder().withName("moduleA-1").withParent(moduleA).build();
+        Project moduleA2 = ProjectBuilder.builder().withName("moduleA-2").withParent(moduleA).build();
+        Project moduleB = ProjectBuilder.builder().withName("moduleB").withParent(rootProject).build();
+        Project moduleB1 = ProjectBuilder.builder().withName("moduleB-1").withParent(moduleB).build();
+        Project moduleB2 = ProjectBuilder.builder().withName("moduleB-2").withParent(moduleB).build();
+        Map<Project, Variant> projectVariantMap = new HashMap<>();
+        projectVariantMap.put(moduleA1, version1);
+        projectVariantMap.put(moduleA2, version2);
+        projectVariantMap.put(moduleB1, version1);
+        projectVariantMap.put(moduleB2, version2);
+
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryMock(projectVariantMap);
+        ProjectExtension projectExtension = new ProjectExtension(rootProject, variantProjectFactory);
+
+        Project moduleA1Project = projectExtension.findProject(":moduleA", version1);
+        assertNotNull(moduleA1Project);
+        assertEquals(moduleA1, moduleA1Project);
+
+        Project moduleA2Project = projectExtension.findProject(":moduleA", version2);
+        assertNotNull(moduleA2Project);
+        assertEquals(moduleA2, moduleA2Project);
+
+        Project moduleA3Project = projectExtension
+                .findProject(":moduleA", TestUtil.createVariant(Collections.singletonMap("systemVersion", "3.0")));
+        assertNull(moduleA3Project);
+    }
+
+    public void project() {
+        Variant version1 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"));
+        Variant version2 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"));
+        Project rootProject = ProjectBuilder.builder().build();
+        Project moduleA = ProjectBuilder.builder().withName("moduleA").withParent(rootProject).build();
+        Project moduleA1 = ProjectBuilder.builder().withName("moduleA-1").withParent(moduleA).build();
+        Project moduleA2 = ProjectBuilder.builder().withName("moduleA-2").withParent(moduleA).build();
+        Project moduleB = ProjectBuilder.builder().withName("moduleB").withParent(rootProject).build();
+        Project moduleB1 = ProjectBuilder.builder().withName("moduleB-1").withParent(moduleB).build();
+        Project moduleB2 = ProjectBuilder.builder().withName("moduleB-2").withParent(moduleB).build();
+        Map<Project, Variant> projectVariantMap = new HashMap<>();
+        projectVariantMap.put(moduleA1, version1);
+        projectVariantMap.put(moduleA2, version2);
+        projectVariantMap.put(moduleB1, version1);
+        projectVariantMap.put(moduleB2, version2);
+
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryMock(projectVariantMap);
+        ProjectExtension projectExtension = new ProjectExtension(rootProject, variantProjectFactory);
+
+        Project moduleA1Project = projectExtension
+                .project(":moduleA", TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0")));
+        assertEquals(moduleA1, moduleA1Project);
+    }
+
+    @Test(expected = UnknownProjectException.class)
+    public void projectNotPresent() {
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryMock(Collections.emptyMap());
+        Project rootProject = ProjectBuilder.builder().build();
+        ProjectExtension projectExtension = new ProjectExtension(rootProject, variantProjectFactory);
+
+        projectExtension.project(":moduleA", TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0")));
+    }
+
+    @Test
+    public void variantTask() {
+        Variant version1 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"));
+        Variant version2 = TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"));
+        Project rootProject = ProjectBuilder.builder().build();
+        Project moduleA = ProjectBuilder.builder().withName("moduleA").withParent(rootProject).build();
+        Project moduleA1 = ProjectBuilder.builder().withName("moduleA-1").withParent(moduleA).build();
+        Project moduleA2 = ProjectBuilder.builder().withName("moduleA-2").withParent(moduleA).build();
+        Project moduleB = ProjectBuilder.builder().withName("moduleB").withParent(rootProject).build();
+        Project moduleB1 = ProjectBuilder.builder().withName("moduleB-1").withParent(moduleB).build();
+        Project moduleB2 = ProjectBuilder.builder().withName("moduleB-2").withParent(moduleB).build();
+        Map<Project, Variant> projectVariantMap = new HashMap<>();
+        projectVariantMap.put(moduleA1, version1);
+        projectVariantMap.put(moduleA2, version2);
+        projectVariantMap.put(moduleB1, version1);
+        projectVariantMap.put(moduleB2, version2);
+
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryMock(projectVariantMap);
+        ProjectExtension projectExtension = new ProjectExtension(rootProject, variantProjectFactory);
+
+        assertEquals(":moduleA:moduleA-1:test", projectExtension.variantTask(":moduleA", version1, "test"));
+    }
+
+}

--- a/src/test/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactoryImplTest.java
+++ b/src/test/java/be/vbgn/gradle/buildaspects/project/project/VariantProjectFactoryImplTest.java
@@ -18,7 +18,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class VariantProjectFactoryTest {
+public class VariantProjectFactoryImplTest {
 
     private ProjectDescriptor createProjectDescriptor(String path) {
         ProjectDescriptor projectDescriptor = Mockito.mock(ProjectDescriptor.class, Mockito.RETURNS_SMART_NULLS);
@@ -46,7 +46,7 @@ public class VariantProjectFactoryTest {
         variantProjectDescriptors.add(createVariantProjectDescriptor(":projectA:projectA-d",
                 TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0"))));
 
-        VariantProjectFactory variantProjectFactory = new VariantProjectFactory(variantProjectDescriptors);
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryImpl(variantProjectDescriptors);
 
         Project rootProject = ProjectBuilder.builder()
                 .withName(":")
@@ -81,7 +81,7 @@ public class VariantProjectFactoryTest {
         variantProjectDescriptors.add(createVariantProjectDescriptor(":projectB:projectB-c",
                 TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"))));
 
-        VariantProjectFactory variantProjectFactory = new VariantProjectFactory(variantProjectDescriptors);
+        VariantProjectFactory variantProjectFactory = new VariantProjectFactoryImpl(variantProjectDescriptors);
 
         Project rootProject = ProjectBuilder.builder()
                 .withName(":")
@@ -102,9 +102,9 @@ public class VariantProjectFactoryTest {
         Set<VariantProject> variantProjects = variantProjectFactory.createVariantProjectsForParent(projectA);
 
         assertEquals(new HashSet<>(Arrays.asList(
-                new VariantProject(projectAC,
+                new VariantProjectImpl(projectAC,
                         TestUtil.createVariant(Collections.singletonMap("systemVersion", "1.0"))),
-                new VariantProject(projectAD,
+                new VariantProjectImpl(projectAD,
                         TestUtil.createVariant(Collections.singletonMap("systemVersion", "2.0")))
         )), variantProjects);
 


### PR DESCRIPTION
Add extra methods on Project to find sibling variants of a project.

For example, from a variant sub-project of `:moduleA`, you can find the matching variant sub-project of `:moduleB` with `project(':moduleB', buildVariant)`

It is also necessary to be able to create task names for such projects. Referring to tasks across projects happens by path instead of by task reference because the evaluation order of those projects is not always defined.