### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 on:
   push:
-    ignore-branches:
-      - 'dependabot/**'
+    branches:
+      - master
+    tags:
+      - v*
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
@@ -20,6 +22,7 @@ jobs:
       - name: Tests
         run: ./gradlew check
       - name: Upload analysis to sonarcloud
+        if: "${{ env.SONAR_TOKEN != '' }}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* Only submit to sonarcloud if the sonar token is available
* Only build for master branch and version tags, other contributions happen via PRs anyways.